### PR TITLE
Adapted ephemeral post params with last slack library.

### DIFF
--- a/docs/advent_2017.md
+++ b/docs/advent_2017.md
@@ -147,7 +147,7 @@ scores!
 // we would ask users to specify a date, or maybe a team, or even
 // a specific game which we could present back
 func (s *Slack) askIntent(ev *slack.MessageEvent) error {
-    params := slack.NewPostEphemeralParameters()
+    params := slack.PostMessageParameters{}
     attachment := slack.Attachment{
         Text:       "Would you like to see the most recent scores?",
         CallbackID: fmt.Sprintf("ask_%s", ev.User),
@@ -176,7 +176,7 @@ func (s *Slack) askIntent(ev *slack.MessageEvent) error {
         ev.Channel,
         ev.User,
         slack.MsgOptionAttachments(params.Attachments...),
-        slack.MsgOptionPostEphemeralParameters(params),
+        slack.MsgOptionPostMessageParameters(params),
     )
     if err != nil {
         return err

--- a/post/utils.go
+++ b/post/utils.go
@@ -104,7 +104,7 @@ func postHandler(w http.ResponseWriter, r *http.Request) {
 // we would ask users to specify a date, or maybe a team, or even
 // a specific game which we could present back
 func (s *Slack) askIntent(ev *slack.MessageEvent) error {
-	params := slack.NewPostEphemeralParameters()
+	params := slack.PostMessageParameters{}
 	attachment := slack.Attachment{
 		Text:       "Would you like to see the most recent scores?",
 		CallbackID: fmt.Sprintf("ask_%s", ev.User),
@@ -133,7 +133,7 @@ func (s *Slack) askIntent(ev *slack.MessageEvent) error {
 		ev.Channel,
 		ev.User,
 		slack.MsgOptionAttachments(params.Attachments...),
-		slack.MsgOptionPostEphemeralParameters(params),
+		slack.MsgOptionPostMessageParameters(params),
 	)
 	if err != nil {
 		return err


### PR DESCRIPTION
Seems, the sample is incompatible with the recent slack library.
During compilation I have got these errors:
```
post/utils.go:107: undefined: slack.NewPostEphemeralParameters
post/utils.go:136: undefined: slack.MsgOptionPostEphemeralParameters
```
See changes in the PR for fix details.
