### PR TITLE
Build on Windows

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,12 @@
+BINARYNAME	:= nhlbot
+BINARYENDING	:=
+ifeq ($(OS),Windows_NT)
+	BINARYENDING = .exe
+endif
+
 all: clean
-	go build -v -o nhlbot main.go
+	go build -v -o $(BINARYNAME)$(BINARYENDING) main.go
 
 .PHONY: clean
 clean:
-	rm -rf ./build nhlbot
+	rm -rf ./build $(BINARYNAME)$(BINARYENDING)

--- a/main.go
+++ b/main.go
@@ -1,4 +1,4 @@
-// +build linux
+// +build linux windows
 
 package main
 


### PR DESCRIPTION
I successfully tested this on Windows and it works great. Two changes needed to be made to get it working:
1. "windows" needed to be added to the build constraints in main.go.
2. Make the Makefile add ".exe" to end of filenames for binaries built on "Windows_NT".